### PR TITLE
Tools/setup: fix the wrong - deprecated - expression in the requireme…

### DIFF
--- a/Tools/setup/requirements.txt
+++ b/Tools/setup/requirements.txt
@@ -8,7 +8,7 @@ jinja2>=2.8
 jsonschema
 kconfiglib
 lxml
-matplotlib>=3.0.*
+matplotlib>=3.0
 numpy>=1.13
 nunavut>=1.1.0
 packaging


### PR DESCRIPTION
Apply fixes for https://github.com/PX4/PX4-Autopilot/pull/23330 so that terrain navigation setup still works.

This is not the only patch that's needed to run again. It might be best to rebase on top of `main`.
